### PR TITLE
fix: rename metainfo `code` -> `codeExternal`

### DIFF
--- a/netverify/netverify-web-v4.md
+++ b/netverify/netverify-web-v4.md
@@ -507,7 +507,7 @@ All data is encoded with [UTF-8](https://tools.ietf.org/html/rfc3629).
 
 |Property|Type|Description|
 |:-------|:---|:----------|
-|**code**|integer|[see **errorCode** values](#after-the-user-journey)|
+|**codeExternal**|integer|[see **errorCode** values](#after-the-user-journey)|
 <br>
 
 ### Example iFrame logging code


### PR DESCRIPTION
`event.data.payload.metainfo` contains `codeExternal` property not as previously written `code`
so this updates the documentation accordingly